### PR TITLE
Reduce authorization service log output

### DIFF
--- a/src/main/java/datawave/microservice/authorization/preauth/ProxiedEntityX509Filter.java
+++ b/src/main/java/datawave/microservice/authorization/preauth/ProxiedEntityX509Filter.java
@@ -153,7 +153,8 @@ public class ProxiedEntityX509Filter extends AbstractPreAuthenticatedProcessingF
         
         if (certs != null && certs.length > 0) {
             if (logger.isDebugEnabled()) {
-                logger.debug("X.509 client authorization certificate: " + certs[0]);
+                logger.debug("X.509 client authorization certificate: [Subject DN: " + certs[0].getSubjectDN().getName() + ", Issuer DN: "
+                                + certs[0].getIssuerDN().getName() + "]");
             }
             
             return certs[0];


### PR DESCRIPTION
Reduces authorization service log output to no longer include the entire certificate. Now outputs the subject DN and issuer DN instead.